### PR TITLE
Add jruby-head and rbx-2 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,10 @@ cache: bundler
 script: 'bundle exec rake test:coverage --trace'
 rvm:
   - 2.2
+  - jruby-head
+  - rbx-2
+
+matrix:
+  allow_failures:
+    - rvm: jruby-head
+    - rvm: rbx-2


### PR DESCRIPTION
* also added rbx-2 as most other components have it
* allowing failures

`jruby-head` fails as `Binding#receiver` seems to be unimplemented, see jruby/jruby#2578