### PR TITLE
Add link_to helper

### DIFF
--- a/lib/lotus/helpers.rb
+++ b/lib/lotus/helpers.rb
@@ -2,6 +2,7 @@ require 'lotus/helpers/version'
 require 'lotus/helpers/html_helper'
 require 'lotus/helpers/escape_helper'
 require 'lotus/helpers/routing_helper'
+require 'lotus/helpers/link_to_helper'
 
 module Lotus
   # View helpers for Ruby applications
@@ -21,6 +22,7 @@ module Lotus
         include Lotus::Helpers::HtmlHelper
         include Lotus::Helpers::EscapeHelper
         include Lotus::Helpers::RoutingHelper
+        include Lotus::Helpers::LinkToHelper
       end
     end
   end

--- a/lib/lotus/helpers/link_to_helper.rb
+++ b/lib/lotus/helpers/link_to_helper.rb
@@ -1,0 +1,28 @@
+require 'lotus/helpers/html_helper'
+
+module Lotus
+  module Helpers
+    # LinkTo Helper
+    #
+    # Including <tt>Lotus::Helpers::LinkTo</tt> will include the `link_to` method.
+    #
+    # @since x.x.x
+    #
+    # @see Lotus::Helpers::HtmlHelper#html
+    #
+    # @example Usage
+    #   # 1
+    #   link_to('home', '/') # => <a href="/">home</a>
+    #
+    #   # 2
+    #   link_to('users', :users_path, class: 'my_users') # => <a href="/users" class="my_users">users</div>
+    module LinkToHelper
+      include Lotus::Helpers::HtmlHelper
+
+      def link_to(content, url, options = {}, &blk)
+        options[:href] = url
+        html.a(blk || content, options).to_s
+      end
+    end
+  end
+end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -232,11 +232,7 @@ class LinkTo
 
   class Routes
     def self.path(name, id = nil)
-      if id
-        "/#{ name }/#{id}"
-      else
-        "/#{ name }"
-      end
+      "/#{name}" << "/#{id}"
     end
   end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -230,6 +230,14 @@ end
 class LinkTo
   include Lotus::Helpers::LinkToHelper
 
+  class Index
+    include TestView
+
+    def link_to_home
+      link_to('Home', '/')
+    end
+  end
+
   class Routes
     def self.path(name, id = nil)
       "/#{name}" << "/#{id}"

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -257,7 +257,7 @@ class LinkTo
   end
 
   def link_to_with_id
-    link_to('Post', routes.path(:posts), id: 'posts_link')
+    link_to('Post', routes.path(:posts), id: 'posts__link')
   end
 
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -226,3 +226,38 @@ class ViewWithoutRoutingHelper
     routes.path(:dashboard)
   end
 end
+
+class LinkTo
+  include Lotus::Helpers::LinkToHelper
+
+  class Routes
+    def self.path(name, id = nil)
+      if id
+        "/#{ name }/#{id}"
+      else
+        "/#{ name }"
+      end
+    end
+  end
+
+  def routes
+    Routes
+  end
+
+  def link_to_posts
+    link_to('Posts', routes.path(:posts))
+  end
+
+  def link_to_post
+    link_to('Post', routes.path(:post, 1))
+  end
+
+  def link_to_with_class
+    link_to('Post', routes.path(:posts), class: 'first')
+  end
+
+  def link_to_with_id
+    link_to('Post', routes.path(:posts), id: 'posts_link')
+  end
+
+end

--- a/test/fixtures/templates/link_to/index.html.erb
+++ b/test/fixtures/templates/link_to/index.html.erb
@@ -1,0 +1,1 @@
+<%= link_to_home %>

--- a/test/integration/link_to_helper_test.rb
+++ b/test/integration/link_to_helper_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+describe 'Escape helper' do
+  before do
+    @user   = LinkTo.new()
+    @actual = LinkTo::Index.render(format: :html)
+  end
+
+  it 'renders the title' do
+    @actual.must_match(%(<a href="/">Home</a>))
+  end
+end

--- a/test/link_to_helper_test.rb
+++ b/test/link_to_helper_test.rb
@@ -6,7 +6,7 @@ describe Lotus::Helpers::LinkToHelper do
   end
 
   it 'returns a link to posts' do
-    @view.link_to_posts.must_equal %(<a href="/posts">Posts</a>)
+    @view.link_to_posts.must_equal %(<a href="/posts/">Posts</a>)
   end
 
   it 'returns a link to a post' do
@@ -14,10 +14,10 @@ describe Lotus::Helpers::LinkToHelper do
   end
 
   it 'returns a link with a class' do
-    @view.link_to_with_class.must_equal %(<a class="first" href="/posts">Post</a>)
+    @view.link_to_with_class.must_equal %(<a class="first" href="/posts/">Post</a>)
   end
 
   it 'returns a link with id' do
-    @view.link_to_with_id.must_equal %(<a id="posts__link" href="/posts">Post</a>)
+    @view.link_to_with_id.must_equal %(<a id="posts__link" href="/posts/">Post</a>)
   end
 end

--- a/test/link_to_helper_test.rb
+++ b/test/link_to_helper_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+describe Lotus::Helpers::LinkToHelper do
+  before do
+    @view = LinkTo.new
+  end
+
+  it 'returns a link to posts' do
+    @view.link_to_posts.must_equal %(<a href="/posts">Posts</a>)
+  end
+
+  it 'returns a link to a post' do
+    @view.link_to_post.must_equal %(<a href="/post/1">Post</a>)
+  end
+
+  it 'returns a link with a class' do
+    @view.link_to_with_class.must_equal %(<a class="first" href="/posts">Post</a>)
+  end
+
+  it 'returns a link with id' do
+    @view.link_to_with_id.must_equal %(<a id="posts_link" href="/posts">Post</a>)
+  end
+end

--- a/test/link_to_helper_test.rb
+++ b/test/link_to_helper_test.rb
@@ -18,6 +18,6 @@ describe Lotus::Helpers::LinkToHelper do
   end
 
   it 'returns a link with id' do
-    @view.link_to_with_id.must_equal %(<a id="posts_link" href="/posts">Post</a>)
+    @view.link_to_with_id.must_equal %(<a id="posts__link" href="/posts">Post</a>)
   end
 end


### PR DESCRIPTION
LinkTo Helper
===========

Provides a helper method for generating links. As dicussed on [discuss.lotusrb.org #58](https://discuss.lotusrb.org/t/link-to-view-helper/58)

#### Example Usage

    link_to 'blogs', :blogs_path
    link_to 'archives', '/archives', class: archives