### PR TITLE
Improve link_to with html content param

### DIFF
--- a/lib/lotus/helpers/link_to_helper.rb
+++ b/lib/lotus/helpers/link_to_helper.rb
@@ -9,17 +9,49 @@ module Lotus
     # @since x.x.x
     #
     # @see Lotus::Helpers::HtmlHelper#html
-    #
-    # @example Usage
-    #   # 1
-    #   link_to('home', '/') # => <a href="/">home</a>
-    #
-    #   # 2
-    #   link_to('users', :users_path, class: 'my_users') # => <a href="/users" class="my_users">users</div>
     module LinkToHelper
       include Lotus::Helpers::HtmlHelper
 
-      def link_to(content, url, options = {}, &blk)
+      # Link to url using content or html block
+      #
+      # @overload link_to(content, url, options)
+      #   Use string as content
+      #   @param content [String] content used in the a tag
+      #   @param url [String] url used in href attribute
+      #   @param options [Hash] HTML attributes to pass to the a tag
+      #
+      # @overload link_to(url, options, &blk)
+      #   Use block as content
+      #   @param url [String] url used in href attribute
+      #   @param options [Hash] HTML attributes to pass to the a tag
+      #   @param blk [Proc] A block that describes the contents of the a tag
+      #
+      # @return [String] the a tag
+      #
+      # @since x.x.x
+      #
+      # @example Usage
+      #   # 1
+      #   link_to('home', '/') # => <a href="/">home</a>
+      #
+      #   # 2
+      #   link_to('users', :users_path, class: 'my_users') # => <a href="/users" class="my_users">users</div>
+      #
+      #   # 3
+      #   link_to(:users_path) do
+      #     strong 'Users'
+      #   end # => <a href="/users"><strong>Users</strong></a>
+      def link_to(*args, **options, &blk)
+        if block_given? && args.size != 1
+          raise ArgumentError, 'Only an url is expected as an argument when a block is given'
+        end
+
+        if !block_given? && args.size != 2
+          raise ArgumentError, 'Both content and url are expected as arguments'
+        end
+
+        url, content = *args.rotate
+
         options[:href] = url
         html.a(blk || content, options).to_s
       end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -437,6 +437,32 @@ class LinkTo
     def link_to_home
       link_to('Home', '/')
     end
+
+    def link_to_relative
+      link_to('Relative', 'relative')
+    end
+
+    def link_to_home_with_html_content
+      link_to('/') do
+        p 'Home with html content'
+      end
+    end
+
+    def link_to_home_with_html_content_id_and_class
+      link_to('/', id: 'home__link', class: 'first') do
+        p 'Home with html content, id and class'
+      end
+    end
+
+    def link_to_external_url_with_content
+      link_to('External', 'http://external.com')
+    end
+
+    def link_to_external_url_with_html_content
+      link_to('http://external.com') do
+        strong 'External with html content'
+      end
+    end
   end
 
   class Routes
@@ -447,6 +473,10 @@ class LinkTo
 
   def routes
     Routes
+  end
+
+  def link_to_relative_posts
+    link_to('Posts', 'posts')
   end
 
   def link_to_posts
@@ -463,6 +493,38 @@ class LinkTo
 
   def link_to_with_id
     link_to('Post', routes.path(:posts), id: 'posts__link')
+  end
+
+  def link_to_with_html_content
+    link_to(routes.path(:posts)) do
+      strong 'Post'
+    end
+  end
+
+  def link_to_with_content_and_html_content
+    link_to('Post', routes.path(:posts)) do
+      strong 'Post'
+    end
+  end
+
+  def link_to_with_html_content_id_and_class
+    link_to(routes.path(:posts), id: 'posts__link', class: 'first') do
+      strong 'Post'
+    end
+  end
+
+  def link_to_without_args
+    link_to
+  end
+
+  def link_to_with_only_content
+    link_to 'Post'
+  end
+
+  def link_to_with_content_html_content_id_and_class
+    link_to('Post', routes.path(:posts), id: 'posts__link', class: 'first') do
+      strong 'Post'
+    end
   end
 
 end

--- a/test/fixtures/templates/link_to/index.html.erb
+++ b/test/fixtures/templates/link_to/index.html.erb
@@ -1,1 +1,6 @@
 <%= link_to_home %>
+<%= link_to_relative %>
+<%= link_to_home_with_html_content %>
+<%= link_to_home_with_html_content_id_and_class %>
+<%= link_to_external_url_with_content %>
+<%= link_to_external_url_with_html_content %>

--- a/test/integration/link_to_helper_test.rb
+++ b/test/integration/link_to_helper_test.rb
@@ -9,4 +9,24 @@ describe 'Escape helper' do
   it 'renders the title' do
     @actual.must_match(%(<a href="/">Home</a>))
   end
+
+  it 'renders relative link' do
+    @actual.must_match(%(<a href="relative">Relative</a>))
+  end
+
+  it 'renders link using html content' do
+    @actual.must_match(%(<a href="/">\n<p>Home with html content</p>\n</a>))
+  end
+
+  it 'renders link using html content, id and class' do
+    @actual.must_match(%(<a id="home__link" class="first" href="/">\n<p>Home with html content, id and class</p>\n</a>))
+  end
+
+  it 'renders link using content' do
+    @actual.must_match(%(<a href="http://external.com">External</a>))
+  end
+
+  it 'renders link using html content' do
+    @actual.must_match(%(<a href="http://external.com">\n<strong>External with html content</strong>\n</a>))
+  end
 end

--- a/test/link_to_helper_test.rb
+++ b/test/link_to_helper_test.rb
@@ -20,4 +20,32 @@ describe Lotus::Helpers::LinkToHelper do
   it 'returns a link with id' do
     @view.link_to_with_id.must_equal %(<a id="posts__link" href="/posts/">Post</a>)
   end
+
+  it 'returns a link relative link' do
+    @view.link_to_relative_posts.must_equal %(<a href="posts">Posts</a>)
+  end
+
+  it 'returns a link with html content' do
+    @view.link_to_with_html_content.must_equal %(<a href="/posts/">\n<strong>Post</strong>\n</a>)
+  end
+
+  it 'returns a link with html content, id and class' do
+    @view.link_to_with_html_content_id_and_class.must_equal %(<a id="posts__link" class="first" href="/posts/">\n<strong>Post</strong>\n</a>)
+  end
+
+  it 'raises an exception link with content and html content' do
+    -> { @view.link_to_with_content_and_html_content }.must_raise ArgumentError, 'Only an url is expected as an argument when a block is given'
+  end
+
+  it 'raises an exception when link with content, html content, id and class' do
+    -> { @view.link_to_with_content_html_content_id_and_class }.must_raise ArgumentError, 'Only an url is expected as an argument when a block is given'
+  end
+
+  it 'raises an exception when have not arguments' do
+    -> { @view.link_to_without_args }.must_raise ArgumentError, 'Both content and url are expected as arguments'
+  end
+
+  it 'raises an exception when have only content' do
+    -> { @view.link_to_with_only_content }.must_raise ArgumentError, 'Both content and url are expected as arguments'
+  end
 end


### PR DESCRIPTION
Improve support for html content in link_to helper

# Before
```ruby
link_to(nil, routes.path(:posts)) do
  strong 'Post'
end
# => <a href="/posts/"><strong>Post</strong></a>
```

# Now
```ruby
link_to(routes.path(:posts)) do
  strong 'Post'
end
# => <a href="/posts/"><strong>Post</strong></a>
```
