### PR TITLE
Added support for boolean attributes.

### DIFF
--- a/lib/lotus/helpers/html_helper/empty_html_node.rb
+++ b/lib/lotus/helpers/html_helper/empty_html_node.rb
@@ -6,6 +6,20 @@ module Lotus
       # @since 0.1.0
       # @api private
       class EmptyHtmlNode
+        # List of attributes that get special treatment when rendering.
+        # @see http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#boolean-attribute
+        # @since x.x.x
+        # @api private
+        BOOLEAN_ATTRIBUTES = %w{allowfullscreen async autobuffer autofocus
+          autoplay checked compact controls declare default defaultchecked
+          defaultmuted defaultselected defer disabled draggable enabled
+          formnovalidate hidden indeterminate inert ismap itemscope loop
+          multiple muted nohref noresize noshade novalidate nowrap open
+          pauseonexit pubdate readonly required reversed scoped seamless
+          selected sortable spellcheck translate truespeed typemustmatch
+          visible
+        }.freeze
+
         # Attributes separator
         #
         # @since 0.1.0
@@ -45,13 +59,30 @@ module Lotus
         # @api private
         def attributes
           return if @attributes.nil?
-          result = [nil]
+          result = ''
 
-          @attributes.each do |name, value|
-            result << %(#{ name }="#{ value }")
+          @attributes.each do |attribute_name, value|
+            if boolean_attribute?(attribute_name)
+              result << boolean_attribute(attribute_name, value) if value
+            else
+              result << attribute(attribute_name, value)
+            end
           end
 
-          result.join(ATTRIBUTES_SEPARATOR)
+          result
+        end
+
+        def boolean_attribute?(attribute_name)
+          BOOLEAN_ATTRIBUTES.include?(attribute_name.to_s)
+        end
+
+        # Do not render boolean attributes when their value is _false_.
+        def boolean_attribute(attribute_name, value)
+          %(#{ATTRIBUTES_SEPARATOR}#{ attribute_name }="#{ attribute_name }")
+        end
+
+        def attribute(attribute_name, value)
+          %(#{ATTRIBUTES_SEPARATOR}#{ attribute_name }="#{ value }")
         end
       end
     end

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -542,7 +542,7 @@ describe Lotus::Helpers::FormHelper do
         email_field :publisher_email, multiple: true
       end.to_s
 
-      actual.must_include %(<input type="email" name="book[publisher_email]" id="book-publisher-email" value="" multiple="true">)
+      actual.must_include %(<input type="email" name="book[publisher_email]" id="book-publisher-email" value="" multiple="multiple">)
     end
 
     it "allows to specify HTML attributes" do
@@ -625,7 +625,7 @@ describe Lotus::Helpers::FormHelper do
         file_field :image_cover, multiple: true
       end.to_s
 
-      actual.must_include %(<input type="file" name="book[image_cover]" id="book-image-cover" multiple="true">)
+      actual.must_include %(<input type="file" name="book[image_cover]" id="book-image-cover" multiple="multiple">)
     end
 
     it "allows to specify single value for 'accept' attribute" do

--- a/test/html_helper/html_builder_test.rb
+++ b/test/html_helper/html_builder_test.rb
@@ -144,4 +144,56 @@ CONTENT
       result.must_equal %(<meta http-equiv="refresh" content="23;url=http://lotusrb.org">)
     end
   end
+
+  ##############################################################################
+  # ATTRIBUTES                                                                 #
+  ##############################################################################
+
+  describe 'attributes' do
+    it 'handles no attribute list' do
+      result = @builder.input().to_s
+      result.must_equal('<input>')
+    end
+
+    it 'handles empty attribute list' do
+      result = @builder.input({}).to_s
+      result.must_equal('<input>')
+    end
+
+    it 'handles nil attribute list' do
+      result = @builder.input(nil).to_s
+      result.must_equal('<input>')
+    end
+
+    it 'does not render boolean attribute when its value is false' do
+      result = @builder.input(required: false).to_s
+      result.must_equal('<input>')
+    end
+
+    it 'does not render boolean attribute when its value is nil' do
+      result = @builder.input(required: nil).to_s
+      result.must_equal('<input>')
+    end
+
+    it 'does render boolean attribute when its value is true' do
+      result = @builder.input(required: true).to_s
+      result.must_equal('<input required="required">')
+    end
+
+    it 'does render boolean attribute when its value is trueish' do
+      result = @builder.input(required: 'yes').to_s
+      result.must_equal('<input required="required">')
+    end
+
+    it 'also handles strings for detection of boolean attributes' do
+      result = @builder.input('required': true).to_s
+      result.must_equal('<input required="required">')
+    end
+
+    it 'renders multiple attributes' do
+      result = @builder.input('required': true, 'something': 'bar').to_s
+      result.must_equal('<input required="required" something="bar">')
+    end
+
+  end
 end


### PR DESCRIPTION
Boolean attributes are rendered differently than normal attributes.
If its value is _false_ then the whole attribute is omitted.
If its value is _true_ then the attribute is rendered with its name as the value.

+ added special handling of boolean attributes
+ added tests
! fixed existing tests that checked for „true“ values in rendered boolean attributes