### PR TITLE
Fixes failed routing helper integration test

### DIFF
--- a/test/integration/routing_helper_test.rb
+++ b/test/integration/routing_helper_test.rb
@@ -6,6 +6,6 @@ describe 'Routing helper' do
   end
 
   it 'uses helper' do
-    @actual.must_equal %(/dashboard)
+    @actual.must_include %(/dashboard)
   end
 end


### PR DESCRIPTION
Since the problem does not occur on all  platforms (i.e. not on CI) i assume that the line ending is handled differently.