### PR TITLE
Add support for text inside other tags.

### DIFF
--- a/lib/lotus/helpers/html_helper/html_builder.rb
+++ b/lib/lotus/helpers/html_helper/html_builder.rb
@@ -3,6 +3,7 @@ require 'lotus/utils/class_attribute'
 require 'lotus/utils/escape'
 require 'lotus/helpers/html_helper/empty_html_node'
 require 'lotus/helpers/html_helper/html_node'
+require 'lotus/helpers/html_helper/text_node'
 
 module Lotus
   module Helpers
@@ -250,6 +251,32 @@ module Lotus
         #   html.empty_tag(:xr, id: 'foo', 'data-xyz': 'bar') # => <xr id="foo" data-xyz="bar">
         def empty_tag(name, attributes = nil)
           @nodes << EmptyHtmlNode.new(name, attributes)
+          self
+        end
+
+        # Defines a plain string of text. This particularly useful when you
+        # want to build more complex HTML.
+        #
+        # @param content [String] the text to be rendered.
+        #
+        # @return [self]
+        #
+        # @see Lotus::Helpers::HtmlHelper
+        # @see Lotus::Helpers::HtmlHelper::TextNode
+        #
+        # @example
+        #
+        #   html.label do
+        #     text "Option 1"
+        #     radio_button :option, 1
+        #   end
+        #
+        #   # <label>
+        #   #   Option 1
+        #   #   <input type="radio" name="option" value="1" />
+        #   # </label>
+        def text(content)
+          @nodes << TextNode.new(content)
           self
         end
 

--- a/lib/lotus/helpers/html_helper/text_node.rb
+++ b/lib/lotus/helpers/html_helper/text_node.rb
@@ -1,0 +1,30 @@
+module Lotus
+  module Helpers
+    module HtmlHelper
+      # Text node. Allows for text to be inserted between HTML tags.
+      #
+      # @since x.x.x
+      # @api private
+      class TextNode
+        # Initialize a new text node
+        #
+        # @param content [String] The content to be added.
+        #
+        # @return [Lotus::Helpers::HtmlHelper::TextNode]
+        def initialize content
+          @content = content
+        end
+
+        # Resolve and return the output
+        #
+        # @return [String] the output
+        #
+        # @since x.x.x
+        # @api private
+        def to_s
+          Utils::Escape.html(@content)
+        end
+      end
+    end
+  end
+end

--- a/test/html_helper/html_builder_test.rb
+++ b/test/html_helper/html_builder_test.rb
@@ -196,4 +196,29 @@ CONTENT
     end
 
   end
+
+  ##############################################################################
+  # TEXT
+  ##############################################################################
+
+  describe "regular text" do
+    it "renders plain text" do
+      result = @builder.text('Foo').to_s
+      result.must_equal('Foo')
+    end
+
+    it "renders plain text inside a tag" do
+      result = @builder.p do
+        span('Foo')
+        text('Bar')
+      end.to_s
+
+      result.must_equal(%(<p>\n<span>Foo</span>\nBar\n</p>))
+    end
+
+    it "escapes HTML inside" do
+      result = @builder.text(%(<p>Foo</p>)).to_s
+      result.must_equal('&lt;p&gt;Foo&lt;&#x2F;p&gt;')
+    end
+  end
 end


### PR DESCRIPTION
This feature allows for more complex structures to be defined. One example is the one of a label with a radio button or a checkbox:

```ruby
builder.label do
  text "Option 1"
  radio_button :option, 1
end
```