### PR TITLE
Fix attribution of HTML attributes.

### DIFF
--- a/lib/lotus/helpers/form_helper/form_builder.rb
+++ b/lib/lotus/helpers/form_helper/form_builder.rb
@@ -526,6 +526,11 @@ module Lotus
         #   # Output:
         #   #  <textarea name="user[hobby]" id="user-hobby">Football</textarea>
         def text_area(name, content = nil, attributes = {})
+          if content.is_a? Hash
+            attributes = content
+            content = nil
+          end
+
           attributes = {name: _input_name(name), id: _input_id(name)}.merge(attributes)
           _content = content || _value(name)
           textarea(_content, attributes)

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -762,6 +762,14 @@ describe Lotus::Helpers::FormHelper do
       actual.must_include %(<textarea name="book[description]" id="book-description" class="form-control" cols="5"></textarea>)
     end
 
+    it "renders all HTML attributes along with the name and id" do
+      actual = view.form_for(:book, action) do
+        text_area :description, class: 'form-control', cols: '5'
+      end.to_s
+
+      actual.must_include %(<textarea name="book[description]" id="book-description" class="form-control" cols="5"></textarea>)
+    end
+
     describe "set content explicitly" do
       let(:content) { "A short description of the book" }
       it "allows to set content" do
@@ -794,6 +802,7 @@ describe Lotus::Helpers::FormHelper do
       end
     end
   end
+
   describe "#text_field" do
     it "renders" do
       actual = view.form_for(:book, action) do


### PR DESCRIPTION
Relates to #32.
    
In the scenario of having extra HTML attributes without some content being
passed in, the attributes hash was being set to nil while the content variable
holding the attributes hash.
    
In the scenario:
    
```ruby
form_for :book do
  text_area :description, rows: 5
end
```

The `content` argument was `{ rows: 5 }` and `attributes` was `{}`.

This is still a pretty ugly solution. I need some feedback on this.