### PR TITLE
FormBuilder doesn't inject hidden fields on GET requests

### DIFF
--- a/lib/lotus/helpers/form_helper/form_builder.rb
+++ b/lib/lotus/helpers/form_helper/form_builder.rb
@@ -114,6 +114,7 @@ module Lotus
             @name       = form.name
             @values     = Values.new(form.values, @context.params)
             @attributes = attributes
+            @method     = method
             @csrf_token = csrf_token
           end
         end
@@ -792,14 +793,16 @@ module Lotus
         # @api private
         # @since 0.2.0
         def _method_override!
-          verb = (@attributes.fetch(:method) { DEFAULT_METHOD }).to_s.upcase
-
-          if BROWSER_METHODS.include?(verb)
-            @attributes[:method] = verb
+          if BROWSER_METHODS.include?(@method)
+            @attributes[:method] = @method
           else
             @attributes[:method] = DEFAULT_METHOD
-            @verb                = verb
+            @verb                = @method
           end
+        end
+
+        def method
+          (@attributes.fetch(:method) { DEFAULT_METHOD }).to_s.upcase
         end
 
         # Return CSRF Protection token from view context
@@ -807,7 +810,7 @@ module Lotus
         # @api private
         # @since 0.2.0
         def csrf_token
-          @context.csrf_token if @context.respond_to?(:csrf_token) && @attributes[:method] != 'GET'
+          @context.csrf_token if @context.respond_to?(:csrf_token) && @method != 'GET'
         end
 
         # Return a set of default HTML attributes

--- a/lib/lotus/helpers/form_helper/form_builder.rb
+++ b/lib/lotus/helpers/form_helper/form_builder.rb
@@ -807,7 +807,7 @@ module Lotus
         # @api private
         # @since 0.2.0
         def csrf_token
-          @context.csrf_token if @context.respond_to?(:csrf_token)
+          @context.csrf_token if @context.respond_to?(:csrf_token) && @attributes[:method] != 'GET'
         end
 
         # Return a set of default HTML attributes

--- a/test/form_helper_test.rb
+++ b/test/form_helper_test.rb
@@ -73,6 +73,15 @@ describe Lotus::Helpers::FormHelper do
         end
       end
 
+      describe "with csrf_token on get verb" do
+        let(:csrf_token) { 'abcd-1234-xyz' }
+
+        it "doesn't inject hidden field" do
+          actual = view.form_for(:book, action, method: 'GET', class: 'form-horizonal') { }
+          actual.to_s.must_equal %(<form action="/books" method="GET" accept-charset="utf-8" id="book-form" class="form-horizonal">\n\n</form>)
+        end
+      end
+
       [:patch, :put, :delete].each do |verb|
         it "it injects hidden field when Method Override (#{ verb }) is active" do
           actual = view.form_for(:book, action, method: verb) do


### PR DESCRIPTION
I made this little change to prevent FormHelper to inject the csrf_token hidden field on GET requests, like search forms or button links.

Please consider to merge to master. Tks