### PR TITLE
Add video tag helper

### DIFF
--- a/lib/lotus/helpers.rb
+++ b/lib/lotus/helpers.rb
@@ -5,6 +5,7 @@ require 'lotus/helpers/routing_helper'
 require 'lotus/helpers/link_to_helper'
 require 'lotus/helpers/form_helper'
 require 'lotus/helpers/number_formatting_helper'
+require 'lotus/helpers/video_helper'
 
 module Lotus
   # View helpers for Ruby applications
@@ -27,6 +28,7 @@ module Lotus
         include Lotus::Helpers::LinkToHelper
         include Lotus::Helpers::FormHelper
         include Lotus::Helpers::NumberFormattingHelper
+        include Lotus::Helpers::VideoHelper
       end
     end
   end

--- a/lib/lotus/helpers/video_helper.rb
+++ b/lib/lotus/helpers/video_helper.rb
@@ -1,0 +1,86 @@
+module Lotus
+  module Helpers
+    module VideoHelper
+      include Lotus::Helpers::HtmlHelper
+
+      # Generates a video tag for the given arguments.
+      #
+      # Contents are automatically escaped.
+      #
+      # @overload link_to(content, url, options)
+      #   Use string as content
+      #   @param content [String] content used in the a tag
+      #   @param url [String] url used in href attribute
+      #   @param options [Hash] HTML attributes to pass to the a tag
+      #
+      # @overload link_to(url, options, &blk)
+      #   Use block as content
+      #   @param url [String] url used in href attribute
+      #   @param options [Hash] HTML attributes to pass to the a tag
+      #   @param blk [Proc] A block that describes the contents of the a tag
+      #
+      # @return [String] HTML markup for the video
+      #
+      # @raise [ArgumentError] if the signature isn't respected
+      #
+      # @since 0.5.0
+      #
+      # @see Lotus::Helpers::HtmlHelper#html
+      #
+      # @example Basic usage
+      #   <%= video('movie.mp4') %>
+      #     # => <video src="/assets/movie.mp4"></video>
+      #
+      # @example HTML attributes
+      #   <%= video('movie.mp4', autoplay: true, controls: true) %>
+      #     # => <video src="/assets/movie.mp4" autoplay="autoplay" controls="controls"></video>
+      #
+      # @example Fallback Content
+      #   <%=
+      #     video('movie.mp4') do
+      #       "Your browser does not support the video tag"
+      #     end
+      #   %>
+      #     # => <video src="/assets/movie.mp4">\nYour browser does not support the video tag\n</video>
+      #
+      # @example Tracks
+      #   <%=
+      #     video('movie.mp4') do
+      #       track kind: 'captions', src: view.asset_path('movie.en.vtt'), srclang: 'en', label: 'English'
+      #     end
+      #   %>
+      #     # => <video src="/assets/movie.mp4">\n<track kind="captions" src="/assets/movie.en.vtt" srclang="en" label="English">\n</video>
+      #
+      # @example Sources
+      #   <%=
+      #     video do
+      #       text "Your browser does not support the video tag"
+      #       source src: view.asset_path('movie.mp4'), type: 'video/mp4'
+      #       source src: view.asset_path('movie.ogg'), type: 'video/ogg'
+      #     end
+      #   %>
+      #     # => <video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>
+      #
+      # @example Without any argument
+      #   <%= video %>
+      #     # => ArgumentError
+      #
+      # @example Without src and without block
+      #   <%= video(content: true) %>
+      #     # => ArgumentError
+      def video(src = nil, options = {}, &blk)
+        if src.is_a?(String)
+          options = {src: asset_path(src)}.merge(options)
+        elsif src.is_a?(Hash)
+          options = src
+        end
+
+        if !options[:src] && !block_given?
+          raise ArgumentError
+        end
+
+        html.video(blk, options).to_s
+      end
+    end
+  end
+end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -284,6 +284,19 @@ class FormHelperView
   end
 end
 
+class VideoHelperView
+  include Lotus::Helpers::VideoHelper
+  attr_reader :params
+
+  def initialize(params)
+    @params = Lotus::Action::Params.new(params)
+  end
+
+  def asset_path(url)
+    "/assets/#{url}"
+  end
+end
+
 class SessionFormHelperView < FormHelperView
   def initialize(params, csrf_token)
     super(params)

--- a/test/video_helper_test.rb
+++ b/test/video_helper_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+describe Lotus::Helpers::VideoHelper do
+  let(:view)   { VideoHelperView.new(params) }
+  let(:params) { Hash[] }
+
+  describe '#video' do
+    it 'renders' do
+      actual = view.video('movie.mp4')
+      actual.must_equal %(<video src="/assets/movie.mp4"></video>)
+    end
+
+    it 'renders with html attributes' do
+      actual = view.video('movie.mp4', autoplay: true, controls: true)
+      actual.must_equal %(<video src="/assets/movie.mp4" autoplay="autoplay" controls="controls"></video>)
+    end
+
+    it 'renders with fallback content' do
+      actual = view.video('movie.mp4') do
+        "Your browser does not support the video tag"
+      end
+      actual.must_equal %(<video src="/assets/movie.mp4">\nYour browser does not support the video tag\n</video>)
+    end
+
+    it 'renders with tracks' do
+      actual = view.video('movie.mp4') do
+        track kind: 'captions', src: view.asset_path('movie.en.vtt'), srclang: 'en', label: 'English'
+      end
+      actual.must_equal %(<video src="/assets/movie.mp4">\n<track kind="captions" src="/assets/movie.en.vtt" srclang="en" label="English">\n</video>)
+    end
+
+    it 'renders with sources' do
+      actual = view.video do
+        text "Your browser does not support the video tag"
+        source src: view.asset_path('movie.mp4'), type: 'video/mp4'
+        source src: view.asset_path('movie.ogg'), type: 'video/ogg'
+      end
+      actual.must_equal %(<video>\nYour browser does not support the video tag\n<source src="/assets/movie.mp4" type="video/mp4">\n<source src="/assets/movie.ogg" type="video/ogg">\n</video>)
+    end
+
+    it 'raises an exception when no arguments' do
+      -> {view.video()}.must_raise ArgumentError
+    end
+
+    it 'raises an exception when no src and no block' do
+      -> {view.video(content: true)}.must_raise ArgumentError
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/lotus/lotus/issues/396

This commit exposes a `video` method to the view
which can be used to generate HTML5 video tags.
It accepts options to generate HTML attributes along
with a block for creating fallback content and/or
`source` and `track` tags.