### PR TITLE
Add definition list element 'dd'

### DIFF
--- a/lib/lotus/helpers/html_helper/html_builder.rb
+++ b/lib/lotus/helpers/html_helper/html_builder.rb
@@ -45,6 +45,7 @@ module Lotus
           'div',
           'dl',
           'dt',
+          'dd',
           'em',
           'fieldset',
           'figcaption',


### PR DESCRIPTION
I noticed HtmlBuilder not have definition list element 'dd'.

http://www.w3.org/TR/html4/struct/lists.html#h-10.3

I think it is required.