### PR TITLE
Propose html fragment

### DIFF
--- a/lib/lotus/helpers/html_helper.rb
+++ b/lib/lotus/helpers/html_helper.rb
@@ -65,6 +65,15 @@ module Lotus
     #   #  hello
     #   #</div>
     #
+    #   # 8
+    #   html do
+    #     li 'Hello'
+    #     li 'Lotus'
+    #   end
+    #   # =>
+    #   #<li>Hello</li>
+    #   #<li>Lotus</li>
+    #
     #
     #
     # @example Complex markup
@@ -178,14 +187,20 @@ module Lotus
       private
       # Instantiate an HTML builder
       #
+      # @param blk [Proc,Lotus::Helpers::HtmlHelper::HtmlBuilder,NilClass] the optional content block
+      #
       # @return [Lotus::Helpers::HtmlHelper::HtmlBuilder] the HTML builder
       #
       # @since 0.1.0
       #
       # @see Lotus::Helpers::HtmlHelper
       # @see Lotus::Helpers::HtmlHelper::HtmlBuilder
-      def html
-        HtmlBuilder.new
+      def html(&blk)
+        if block_given?
+          HtmlBuilder.new.fragment(&blk)
+        else
+          HtmlBuilder.new
+        end
       end
     end
   end

--- a/lib/lotus/helpers/html_helper/html_builder.rb
+++ b/lib/lotus/helpers/html_helper/html_builder.rb
@@ -3,6 +3,7 @@ require 'lotus/utils/class_attribute'
 require 'lotus/utils/escape'
 require 'lotus/helpers/html_helper/empty_html_node'
 require 'lotus/helpers/html_helper/html_node'
+require 'lotus/helpers/html_helper/html_fragment'
 require 'lotus/helpers/html_helper/text_node'
 
 module Lotus
@@ -229,6 +230,33 @@ module Lotus
         #   #</custom>
         def tag(name, content = nil, attributes = nil, &blk)
           @nodes << HtmlNode.new(name, blk || content, attributes || content, options)
+          self
+        end
+
+        # Define a HTML fragment
+        #
+        # @param content [String,Lotus::Helpers::HtmlHelper::HtmlBuilder,NilClass] the optional content
+        # @param blk [Proc] the optional nested content espressed as a block
+        #
+        # @return [self]
+        #
+        # @since 0.2.6
+        # @api public
+        #
+        # @see Lotus::Helpers::HtmlHelper
+        #
+        # @example
+        #   html.fragment('Lotus') # => Lotus
+        #
+        #   html do
+        #     p 'hello'
+        #     p 'lotus'
+        #   end
+        #   # =>
+        #     <p>hello</p>
+        #     <p>lotus</p>
+        def fragment(&blk)
+          @nodes << HtmlFragment.new(&blk)
           self
         end
 

--- a/lib/lotus/helpers/html_helper/html_fragment.rb
+++ b/lib/lotus/helpers/html_helper/html_fragment.rb
@@ -1,0 +1,45 @@
+module Lotus
+  module Helpers
+    module HtmlHelper
+      # HTML Fragment
+      #
+      # @since 0.2.6
+      # @api private
+      #
+      # @see Lotus::Helpers::HtmlHelper::HtmlFragment
+      class HtmlFragment
+        # Initialize a HTML Fragment
+        #
+        # @param blk [Proc,Lotus::Helpers::HtmlHelper::HtmlBuilder,NilClass] the content block
+        #
+        # @return [Lotus::Helpers::HtmlHelper::HtmlFragment]
+        def initialize(&blk)
+          @builder = HtmlBuilder.new
+          @blk = blk
+        end
+
+        # Resolve and return the output
+        #
+        # @return [String] the output
+        #
+        # @since 0.2.6
+        # @api private
+        #
+        # @see Lotus::Helpers::HtmlHelper::EmptyHtmlNode#to_s
+        def to_s
+          content.to_s
+        end
+
+        def content
+          result = @builder.resolve(&@blk)
+
+          if @builder.nested?
+            @builder.to_s
+          else
+            "#{ Utils::Escape.html(result) }"
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -39,6 +39,25 @@ class HtmlView
     end
   end
 
+  def concatenation_of_multiple_fragments
+    html { div 'Hello' } + html { div 'Lotus' }
+  end
+
+  def concatenation_of_multiple_divs
+    html.div('Hello') + html.div('Lotus')
+  end
+
+  def concatenation_of_fragment_and_div
+    html { div 'Hello' } + html.div('Lotus')
+  end
+
+  def fragment_with_block_content
+    html do
+      div 'Hello'
+      div 'Lotus'
+    end
+  end
+
   def div_with_attr
     html.div(id: 'container')
   end

--- a/test/html_helper/html_builder_test.rb
+++ b/test/html_helper/html_builder_test.rb
@@ -146,6 +146,21 @@ CONTENT
   end
 
   ##############################################################################
+  # FRAGMENTS
+  ##############################################################################
+
+  describe 'fragment' do
+    it 'generates a html fragment' do
+      result = @builder.fragment do
+        span 'Hello'
+        span 'Lotus'
+      end.to_s
+
+      result.must_equal %(<span>Hello</span>\n<span>Lotus</span>)
+    end
+  end
+
+  ##############################################################################
   # ATTRIBUTES                                                                 #
   ##############################################################################
 

--- a/test/html_helper_test.rb
+++ b/test/html_helper_test.rb
@@ -33,6 +33,22 @@ describe Lotus::Helpers::HtmlHelper do
     @view.div_with_block_content_and_multiple_nested_calls.to_s.must_equal %(<form action="/users" method="POST">\n<div>\n<label for="user-first-name">First name</label>\n<input type="text" id="user-first-name" name="user[first_name]" value="L">\n</div>\n<input type="submit" value="Save changes">\n</form>)
   end
 
+  it 'returns a concatenation of multiple divs' do
+    @view.concatenation_of_multiple_divs.to_s.must_equal %(<div>Hello</div>\n<div>Lotus</div>)
+  end
+
+  it 'returns a concatenation of multiple fragments' do
+    @view.concatenation_of_multiple_fragments.to_s.must_equal %(<div>Hello</div>\n<div>Lotus</div>)
+  end
+
+  it 'returns a concatenation of fragment and div' do
+    @view.concatenation_of_fragment_and_div.to_s.must_equal %(<div>Hello</div>\n<div>Lotus</div>)
+  end
+
+  it 'returns a fragment with block content as string' do
+    @view.fragment_with_block_content.to_s.must_equal %(<div>Hello</div>\n<div>Lotus</div>)
+  end
+
   it 'returns a tag with attribute' do
     @view.div_with_attr.to_s.must_equal %(<div id="container"></div>)
   end


### PR DESCRIPTION
Hello @lotus,

I would like to propose html fragment (or maybe another better name) which will be useful to avoid html string concatenation like

```ruby
html.div("Hello") + html.div("Lotus") + html.div("Ruby")
#=> <div>Hello</div><div>Lotus</div><div>Ruby</div>
```

It looks much better to me with html fragment declaration, especially nested HTML.

```ruby
html do
  div "Hello"
  div "Lotus"
  div "Ruby"
end
```